### PR TITLE
Configure body-parser#urlencoded mandatory options

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -35,7 +35,9 @@ app.use(function(req, res, next) {
 });
 
 app.use(compression());
-app.use(bodyParser.urlencoded());
+app.use(bodyParser.urlencoded({
+  extended: false
+}));
 app.use(bodyParser.json());
 
 app.use('/leaflet.css', express.static(path.join(__dirname, '../node_modules/leaflet/dist/leaflet.css')));

--- a/tools/init-database.js
+++ b/tools/init-database.js
@@ -23,7 +23,7 @@ databaseP
     .then(function(){
         console.log("Success!");
         process.exit();
-    })
+    });
 })
 .catch(function(err){
     console.error("Couldn't connect to database", err);

--- a/tools/restore.js
+++ b/tools/restore.js
@@ -3,7 +3,7 @@
 "use strict";
 
 var child_process = require('child_process');
-var os = require('os')
+var os = require('os');
 var spawn = child_process.spawn;
 
 spawn('pg_restore', ['-p', process.env.DB_PORT_5432_TCP_PORT, '-h', process.env.DB_PORT_5432_TCP_ADDR, '-U', process.env.POSTGRES_USER, '-Fc', '-a', '-j', os.cpus().length, '-d', 'postgres', '/usr/6element-backups/6element.bak'], {stdio: 'inherit'});


### PR DESCRIPTION
By setting it to `false`, body-parser will use Node native `querystring` module.

[More informations](https://www.npmjs.com/package/body-parser#bodyparserurlencodedoptions)